### PR TITLE
Add missing type dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
   "devDependencies": {
     "@types/node": "^20.0.0",
     "@types/react": "^18.0.0",
+    "@types/contentlayer": "*",
+    "@types/clsx": "*",
     "autoprefixer": "^10.0.0",
     "postcss": "^8.0.0",
     "tailwindcss": "^3.0.0",


### PR DESCRIPTION
## Summary
- add `@types/contentlayer` and `@types/clsx` to dev dependencies

## Testing
- `pnpm add -D @types/contentlayer @types/clsx` *(fails: EHOSTUNREACH)*