### PR TITLE
Fix contentlayer path

### DIFF
--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -11,7 +11,7 @@ export const Doc = defineDocumentType(() => ({
 }))
 
 export default makeSource({
-  contentDirPath: 'content',
+  contentDirPath: 'src/content',
   documentTypes: [Doc],
   mdx: { rehypePlugins: [[rehypePrettyCode, { theme: 'one-dark-pro' }]] },
 })


### PR DESCRIPTION
## Summary
- use `src/content` for document root

## Testing
- `npm run lint` *(fails: next not found)*