### PR TITLE
feat: hero section

### DIFF
--- a/public/moon.svg
+++ b/public/moon.svg
@@ -1,0 +1,6 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="50" cy="50" r="40" fill="#f8d9e5" />
+  <path d="M40 40c5 5 5 15 0 20s-15 5-20 0" stroke="#f2a9b8" stroke-width="4" fill="none" stroke-linecap="round" />
+  <circle cx="60" cy="45" r="5" fill="#f2a9b8" />
+  <circle cx="70" cy="55" r="3" fill="#f2a9b8" />
+</svg>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,35 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+#stars {
+  position: absolute;
+  inset: 0;
+  background-color: transparent;
+}
+
+#stars::before,
+#stars::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-repeat: repeat;
+  background-size: 200px 200px;
+  background-image:
+    radial-gradient(#fff 1px, transparent 1px),
+    radial-gradient(#fff 1px, transparent 1px);
+  opacity: 0.6;
+  animation: twinkle 4s linear infinite;
+}
+
+#stars::after {
+  background-size: 250px 250px;
+  animation-delay: 2s;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  #stars::before,
+  #stars::after {
+    animation: none;
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,5 @@
+import Hero from '../components/Hero'
+
 export default function Page() {
-  return (
-    <main className="flex min-h-screen items-center justify-center">
-      <h1 className="text-4xl font-bold">Hello Next.js 14</h1>
-    </main>
-  )
+  return <Hero />
 }

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import { motion, useReducedMotion } from 'framer-motion'
+import Image from 'next/image'
+import StarField from './StarField'
+
+export default function Hero() {
+  const reduce = useReducedMotion()
+
+  const cloudVariants = {
+    animate: (speed: number) => ({
+      x: ['-10%', '110%'],
+      transition: {
+        x: {
+          repeat: Infinity,
+          ease: 'linear',
+          duration: speed,
+        },
+      },
+    }),
+  }
+
+  return (
+    <main className="relative flex h-screen items-center justify-center overflow-hidden bg-white text-black dark:bg-[#0d0c22] dark:text-white">
+      <StarField />
+      <div className="relative z-10 flex flex-col items-center gap-6 md:flex-row md:gap-8">
+        <Image src="/moon.svg" alt="Cranky moon" width={256} height={256} className="h-40 w-40 md:h-56 md:w-56" priority />
+        <p className="text-xl text-center font-light md:text-left">Whimsical goods & celestial musings.</p>
+      </div>
+      {!reduce && (
+        <>
+          <motion.div
+            className="absolute -top-20 left-1/2 h-32 w-60 -translate-x-1/2 rounded-full bg-white/40 blur-md"
+            variants={cloudVariants}
+            custom={40}
+            animate="animate"
+          />
+          <motion.div
+            className="absolute bottom-10 left-1/3 h-40 w-72 rounded-full bg-white/30 blur-md"
+            variants={cloudVariants}
+            custom={60}
+            animate="animate"
+          />
+          <motion.div
+            className="absolute top-1/4 right-0 h-24 w-48 rounded-full bg-white/50 blur-md"
+            variants={cloudVariants}
+            custom={50}
+            animate="animate"
+          />
+        </>
+      )}
+    </main>
+  )
+}

--- a/src/components/StarField.tsx
+++ b/src/components/StarField.tsx
@@ -1,0 +1,9 @@
+export default function StarField() {
+  return (
+    <canvas
+      id="stars"
+      aria-hidden="true"
+      className="absolute inset-0 h-full w-full -z-10 motion-safe:animate-twinkle"
+    />
+  )
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -4,7 +4,17 @@ const config: Config = {
   content: ['./src/app/**/*.{js,ts,jsx,tsx}'],
   darkMode: 'class',
   theme: {
-    extend: {},
+    extend: {
+      keyframes: {
+        twinkle: {
+          '0%, 100%': { opacity: '0.6' },
+          '50%': { opacity: '1' },
+        },
+      },
+      animation: {
+        twinkle: 'twinkle 2s infinite ease-in-out',
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## Summary
- implement star-field twinkle animation with Tailwind keyframes
- replace custom CrankyMoon component with `/public/moon.svg` asset
- display new hero containing the SVG, subtitle, and parallax clouds

## Testing
- `pnpm install --frozen-lockfile --prefer-offline --network-concurrency=1` *(fails: lockfile not compatible)*
- `npm install` *(fails: network unreachable)*
- `npx tsc --noEmit` *(fails: modules not found)*
- `pnpm run lint` *(fails: next not found)*
- `pnpm run build` *(fails: next not found)*