### PR TITLE
feat: blog pages

### DIFF
--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -1,17 +1,21 @@
 import { defineDocumentType, makeSource } from 'contentlayer/source-files'
 import rehypePrettyCode from 'rehype-pretty-code'
 
-export const Doc = defineDocumentType(() => ({
-  name: 'Doc',
+export const Post = defineDocumentType(() => ({
+  name: 'Post',
   filePathPattern: `**/*.mdx`,
   contentType: 'mdx',
   fields: {
     title: { type: 'string', required: true },
+    slug: { type: 'string', required: true },
+    date: { type: 'date', required: true },
+    cover: { type: 'string', required: false },
+    excerpt: { type: 'string', required: true },
   },
 }))
 
 export default makeSource({
   contentDirPath: 'src/content',
-  documentTypes: [Doc],
+  documentTypes: [Post],
   mdx: { rehypePlugins: [[rehypePrettyCode, { theme: 'one-dark-pro' }]] },
 })

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,0 +1,40 @@
+import { notFound } from 'next/navigation'
+import { allPosts } from 'contentlayer/generated'
+import { useMDXComponent } from 'next-contentlayer/hooks'
+
+function formatDate(date: string) {
+  return new Date(date).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+}
+
+export function generateStaticParams() {
+  return allPosts.map((post) => ({ slug: post.slug }))
+}
+
+export default function PostPage({ params }: { params: { slug: string } }) {
+  const post = allPosts.find((p) => p.slug === params.slug)
+  if (!post) return notFound()
+  const MDXContent = useMDXComponent(post.body.code)
+
+  return (
+    <article className="prose dark:prose-invert mx-auto p-4">
+      {post.cover && (
+        <img
+          src={post.cover}
+          alt=""
+          className="rounded-md mb-6 object-cover w-full"
+          width={800}
+          height={400}
+        />
+      )}
+      <h1>{post.title}</h1>
+      <time className="text-sm text-gray-500 dark:text-gray-400">
+        {formatDate(post.date)}
+      </time>
+      <MDXContent />
+    </article>
+  )
+}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,0 +1,50 @@
+import Link from 'next/link'
+import { allPosts } from 'contentlayer/generated'
+
+function formatDate(date: string) {
+  return new Date(date).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+}
+
+export const metadata = {
+  title: 'Blog',
+}
+
+export default function BlogPage() {
+  const posts = allPosts.sort(
+    (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
+  )
+
+  return (
+    <main className="mx-auto max-w-3xl p-4 space-y-8">
+      <h1 className="text-3xl font-bold">Blog</h1>
+      <ul className="space-y-12">
+        {posts.map((post) => (
+          <li key={post._id} className="flex flex-col">
+            <Link href={`/blog/${post.slug}`} className="space-y-2 group">
+              {post.cover && (
+                <img
+                  src={post.cover}
+                  alt=""
+                  className="rounded-md mb-2 object-cover w-full"
+                  width={600}
+                  height={300}
+                />
+              )}
+              <h2 className="text-xl font-semibold group-hover:underline">
+                {post.title}
+              </h2>
+            </Link>
+            <time className="text-sm text-gray-500 dark:text-gray-400">
+              {formatDate(post.date)}
+            </time>
+            <p className="mt-2">{post.excerpt}</p>
+          </li>
+        ))}
+      </ul>
+    </main>
+  )
+}

--- a/src/content/example.mdx
+++ b/src/content/example.mdx
@@ -1,9 +1,0 @@
----
-title: Example Post
----
-
-import { motion } from 'framer-motion'
-
-<motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }}>
-  Hello from Contentlayer!
-</motion.div>

--- a/src/content/first-post.mdx
+++ b/src/content/first-post.mdx
@@ -1,0 +1,17 @@
+---
+title: First Post
+slug: first-post
+date: 2024-01-01
+cover: https://picsum.photos/seed/first/600/300
+excerpt: This is the first sample post.
+---
+
+import { motion } from 'framer-motion'
+
+<motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }}>
+  Hello from the first post!
+</motion.div>
+
+```js
+console.log('Hello world')
+```

--- a/src/content/second-post.mdx
+++ b/src/content/second-post.mdx
@@ -1,0 +1,17 @@
+---
+title: Second Post
+slug: second-post
+date: 2024-02-01
+cover: https://picsum.photos/seed/second/600/300
+excerpt: Another example post to show the blog list.
+---
+
+# Welcome to the second post
+
+Here is some more content written in **Markdown**.
+
+```ts
+function greet(name: string) {
+  return `Hello, ${name}!`
+}
+```


### PR DESCRIPTION
## Summary
- configure Contentlayer to load blog posts
- add sample posts
- list posts on `/blog`
- render post pages with MDX and syntax highlighting

## Testing
- `pnpm lint` *(fails: next not found)*